### PR TITLE
docs: enable Pages & README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pixel Runner
 
-Tiny endless-runner on a plain HTML `<canvas>`. Pure HTML/CSS/JS, no build tools.
+Tiny endless-runner on a plain HTML `<canvas>`. Pure HTML/CSS/JS, no build-in tools.
 
 ## Play
 - Open `index.html` in a browser, or enable GitHub Pages on the repo.


### PR DESCRIPTION
- Linked issues: #8 

- docs(pages): enabled GitHub Pages and link is in README

- File changed:
- README.md